### PR TITLE
Fix userDataDir assignment for Puppeteer launch when NO_CLUSTER=1

### DIFF
--- a/export.js
+++ b/export.js
@@ -290,11 +290,15 @@ else
 					html = decodeURIComponent(
 						zlib.inflateRawSync(
 								Buffer.from(decodeURIComponent(html), 'base64')).toString());
-					
+								
+					const workerSuffix = (!NO_CLUSTER && cluster && cluster.worker)
+							? String(cluster.worker.id)
+							: '1';
+							
 					browser = await puppeteer.launch({
 						headless: 'chrome-headless-shell',
 						args: minimal_args,
-						userDataDir: './puppeteer_user_data' + cluster.worker.id
+						userDataDir: './puppeteer_user_data' + workerSuffix
 					});
 					
 					// Workaround for timeouts/zombies is to kill after 30 secs


### PR DESCRIPTION
when NO_CLUSTER=1 , It will thrw  error：

```
draw.io export server listening on port 8000...
warn: Handled exception: Cannot read properties of undefined (reading 'id') req=ip=::1 format=png w=0 h=0 bg=ffffff  {"stack":"TypeError: Cannot read properties of undefined (reading 'id')\n    at handleRequest (D:\\learn\\draw-image-export2\\export.js:479:62)\n    at Layer.handleRequest (D:\\learn\\draw-image-export2\\node_modules\\router\\lib\\layer.js:152:17)\n    at next (D:\\learn\\draw-image-export2\\node_modules\\router\\lib\\route.js:157:13)\n    at Route.dispatch (D:\\learn\\draw-image-export2\\node_modules\\router\\lib\\route.js:117:3)\n    at handle (D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:435:11)\n    at Layer.handleRequest (D:\\learn\\draw-image-export2\\node_modules\\router\\lib\\layer.js:152:17)\n    at D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:295:15\n    at param (D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:600:14)\n    at param (D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:610:14)\n    at processParams (D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:664:3)"}
::1 - - [19/May/2026:08:40:47 +0000] "POST /ImageExport4/export HTTP/1.1" 500 - "-" "curl/8.5.0"
warn: Handled exception: Cannot read properties of undefined (reading 'id') req=ip=::1 format=png w=0 h=0 bg=ffffff  {"stack":"TypeError: Cannot read properties of undefined (reading 'id')\n    at handleRequest (D:\\learn\\draw-image-export2\\export.js:479:62)\n    at Layer.handleRequest (D:\\learn\\draw-image-export2\\node_modules\\router\\lib\\layer.js:152:17)\n    at next (D:\\learn\\draw-image-export2\\node_modules\\router\\lib\\route.js:157:13)\n    at Route.dispatch (D:\\learn\\draw-image-export2\\node_modules\\router\\lib\\route.js:117:3)\n    at handle (D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:435:11)\n    at Layer.handleRequest (D:\\learn\\draw-image-export2\\node_modules\\router\\lib\\layer.js:152:17)\n    at D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:295:15\n    at param (D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:600:14)\n    at param (D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:610:14)\n    at processParams (D:\\learn\\draw-image-export2\\node_modules\\router\\index.js:664:3)"}
::1 - - [19/May/2026:08:42:08 +0000] "POST /ImageExport4/export HTTP/1.1" 500 - "-" "curl/8.5.0"
```