### PR TITLE
Guard against silent Chrome half-extraction (Node 24.16/24.17 regression)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "start": "node export.js",
     "devstart": "nodemon export.js",
+    "postinstall": "node scripts/check-chrome.js",
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "engines": {
+    "node": ">=24.18.0 <25"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/check-chrome.js
+++ b/scripts/check-chrome.js
@@ -1,0 +1,83 @@
+/**
+ * Post-install sanity check for the Puppeteer-managed Chrome download.
+ *
+ * Why this exists:
+ *   Some Node.js releases (notably 24.16.0 / 24.17.x — see nodejs/node#63487)
+ *   silently half-extract the Chrome .zip during Puppeteer's install. The
+ *   extraction stops before the large `chrome` binary is written, yet npm
+ *   install still exits 0. The breakage only surfaces at runtime as a
+ *   "could not find/launch Chrome" error — long after the build "succeeded".
+ *
+ *   This script turns that silent failure into a loud, build-time failure by
+ *   verifying the resolved Chrome executable actually exists and is a
+ *   plausible size. It runs as the project `postinstall`, after Puppeteer has
+ *   downloaded and extracted Chrome.
+ *
+ * Opt out (e.g. when Chrome is provided by the system or downloads are
+ * intentionally skipped) via any of:
+ *   PUPPETEER_SKIP_DOWNLOAD=1
+ *   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1   (legacy alias)
+ *   PUPPETEER_EXECUTABLE_PATH=/path/to/chrome
+ *   CHECK_CHROME_SKIP=1
+ */
+
+const fs = require('fs');
+
+const TAG = '[check-chrome]';
+
+// A fully-extracted Chrome binary is ~270MB; chrome-headless-shell is smaller
+// but still tens of MB. 40MB is a safe floor that a truncated/partial
+// extraction will fall under while a real binary comfortably clears.
+const MIN_BYTES = 40 * 1024 * 1024;
+
+function truthy(value) {
+	return value === '1' || value === 'true';
+}
+
+const skip =
+	truthy(process.env.PUPPETEER_SKIP_DOWNLOAD) ||
+	truthy(process.env.PUPPETEER_SKIP_CHROMIUM_DOWNLOAD) ||
+	truthy(process.env.CHECK_CHROME_SKIP) ||
+	!!process.env.PUPPETEER_EXECUTABLE_PATH;
+
+if (skip) {
+	console.log(`${TAG} Skipping Chrome verification (skip/exec-path env set).`);
+	process.exit(0);
+}
+
+let puppeteer;
+try {
+	const mod = require('puppeteer');
+	puppeteer = mod && mod.default ? mod.default : mod;
+} catch (err) {
+	// Puppeteer not installed (e.g. `npm install --ignore-scripts` for deps
+	// only). Nothing to verify — don't fail the install.
+	console.log(`${TAG} Puppeteer not resolvable; skipping check (${err.code || err.message}).`);
+	process.exit(0);
+}
+
+let execPath;
+try {
+	execPath = puppeteer.executablePath();
+} catch (err) {
+	console.error(`${TAG} Could not resolve the Puppeteer Chrome path: ${err.message}`);
+	console.error(`${TAG} Ensure Puppeteer installed correctly. If on an affected Node (24.16/24.17.x), reinstall on Node >=24.18.`);
+	process.exit(1);
+}
+
+if (!fs.existsSync(execPath)) {
+	console.error(`${TAG} Chrome binary is MISSING at: ${execPath}`);
+	console.error(`${TAG} This is the signature of a half-extracted download (see nodejs/node#63487).`);
+	console.error(`${TAG} Fix: use Node >=24.18.0, clear ~/.cache/puppeteer, and reinstall.`);
+	process.exit(1);
+}
+
+const { size } = fs.statSync(execPath);
+if (size < MIN_BYTES) {
+	console.error(`${TAG} Chrome binary at ${execPath} is only ${size} bytes ` +
+		`(< ${MIN_BYTES}). Likely a truncated/partial extraction.`);
+	console.error(`${TAG} Fix: use Node >=24.18.0, clear ~/.cache/puppeteer, and reinstall.`);
+	process.exit(1);
+}
+
+console.log(`${TAG} OK: Chrome present at ${execPath} (${Math.round(size / (1024 * 1024))} MB).`);


### PR DESCRIPTION
## Why

Node **24.16.0** and **24.17.x** silently half-extract Puppeteer's Chrome `.zip` during install — extraction stops before the large `chrome` binary is written, yet `npm install` still exits **0**. The break only surfaces at **runtime** as a "could not find/launch Chrome" error, so a Heroku slug / Docker image can build "successfully" and ship broken. Root cause is upstream ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)), fixed in Node **24.18.0**.

Diagnostic fingerprint of the bug: a leftover `*-chrome-linux64.zip` next to a `chrome-linux64/` dir that is missing the `chrome` binary (only `ABOUT`, `MEIPreload/`, `PrivacySandboxAttestationsPreloaded/`, `WidevineCdm/` get written).

Reported in #23.

## What

- **`package.json` — `engines.node`: `">=24.18.0 <25"`.** The Heroku nodejs buildpack honours this and resolves to a known-good runtime. The `<25` ceiling keeps deploys on the line that's confirmed fixed; a sibling report ([max-mapper/extract-zip#154](https://github.com/max-mapper/extract-zip/issues/154)) suggests a similar failure on Node 26.x, so the ceiling is intentional — loosen once newer majors are verified.
- **`scripts/check-chrome.js` — new `postinstall` guard.** Turns the silent failure loud: after Puppeteer's own install runs, it resolves `puppeteer.executablePath()` and **fails the build** (exit 1) if the Chrome binary is missing or implausibly small (< 40 MB; real binary is ~270 MB). This catches a bad extraction regardless of which Node version caused it.

### Safe by design — no-ops instead of false failures when:
- downloads are intentionally skipped — `PUPPETEER_SKIP_DOWNLOAD`, `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`, `PUPPETEER_EXECUTABLE_PATH`, or `CHECK_CHROME_SKIP`
- `puppeteer` isn't installed (e.g. `--ignore-scripts`)

## Notes
- `engines` is advisory to npm unless `engine-strict=true`; the buildpack enforces it for deploys, and the postinstall check is the belt-and-suspenders for local/CI.
- No application code changes — `export.js` is untouched.

## Test plan
- `node --check scripts/check-chrome.js` ✅
- Exercised the skip paths (`PUPPETEER_SKIP_DOWNLOAD=1`, `CHECK_CHROME_SKIP=1`) and the puppeteer-not-installed path → all exit 0 ✅
- `package.json` validates as JSON with the new `engines` + `postinstall` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)